### PR TITLE
Update README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,7 @@ Accepted commands are:
 'standby' - Put playing device on standby via a CEC peripheral
 'toggle' - Toggle state of playing device via a CEC peripheral
 
-example JSON request:
+Example JSON request:
 
 http://localhost:8080/jsonrpc?request={"jsonrpc":"2.0","method":"Addons.ExecuteAddon","params":{"addonid":"script.json-cec","params":{"command":"activate"}},"id":1}
 
@@ -15,8 +15,8 @@ Installation
 
 Method Zip
 
-Download the project as zip and rename it as script.json-cec.zip and import it in Kodi
+Download the project as Zip and rename it as script.json-cec.zip. Use the GUI interface to install it in Kodi.
 
-Method copying
+Method Copying
 
-Clone the project and copy it to kodi's addons directory, example: ~/.kodi/addons/
+Clone the project and copy it to Kodi's addons directory, example: ~/.kodi/addons/

--- a/README.txt
+++ b/README.txt
@@ -10,3 +10,13 @@ Accepted commands are:
 example JSON request:
 
 http://localhost:8080/jsonrpc?request={"jsonrpc":"2.0","method":"Addons.ExecuteAddon","params":{"addonid":"script.json-cec","params":{"command":"activate"}},"id":1}
+
+Installation
+
+Method Zip
+
+Download the project as zip and rename it as script.json-cec.zip and import it in Kodi
+
+Method copying
+
+Clone the project and copy it to kodi's addons directory, example: ~/.kodi/addons/


### PR DESCRIPTION
added install instructions. I previously tried to manually copy the downloaded zip over from my PC but for whatever reason Kodi wasn't happy with it (I then assumed this project was dead), however wget-ing the zip from github on my raspberry pi and then installing saw no issues.

Just a note that this plugin *does* still work. I've just installed it on Kodi 17.1 and successfully turns my TV on/off.

Thanks.