### PR TITLE
Compatibility with Python3/Kodi 19

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.json-cec" name="JSON-CEC" version="0.0.1" provider-name="joshjowen">
 	<requires>
-		<import addon="xbmc.python" version="2.1.0"/>
+		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
 	<extension point="xbmc.python.script" library="script.py">
 		<provides>executable</provides>

--- a/script.py
+++ b/script.py
@@ -1,10 +1,10 @@
 import xbmc
-import urlparse
+import urllib.parse
 import sys
 import time
 
 try:
-        params = urlparse.parse_qs('&'.join(sys.argv[1:]))
+        params = urllib.parse.parse_qs('&'.join(sys.argv[1:]))
         command = params.get('command',None)
 except:
         command = None


### PR DESCRIPTION
This was enough for me to fix the addon on Kodi 19.

I'm sending a PR against the master branch, however according to the main plugin repository docs, Kodi Matrix (19+) should have its own branch that is distinct from all other branches for Kodi 18-. The main reason is that for the plugin repository to show the plugin on Kodi 19, it searches addon.xml and shows only addons that require xbmc-python in version 3.0.0+. That would, on the other hand, disable the plugin on older versions of Kodi. So that's why a separate branch is required for Matrix.